### PR TITLE
Add highlighting support for conditions

### DIFF
--- a/syntaxes/tsconfig.tmLanguage.json
+++ b/syntaxes/tsconfig.tmLanguage.json
@@ -103,10 +103,75 @@
             ]
         },
         "conditions": {
+            "begin": "\\[",
+            "end": "\\]",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.paren.open"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.paren.close"
+                }
+            },
             "patterns": [
                 {
-                    "name": "variable.other.tsconfig",
-                    "match": "\\[(adminUser|language|IP|hostname|applicationContext|hour|minute|month|year|dayofweek|dayofmonth|dayofyear|usergroup|loginUser|page|treeLevel|PIDinRootline|PIDupinRootline|compatVersion|globalVar|globalString|global|userFunc|end|((?:\\{1,2}\\w+|\\w+\\\\{1,2})(?:\\w+\\\\{0,2})+)).*\\]"
+                    "match": "(adminUser|language|IP|hostname|applicationContext|hour|minute|month|year|dayofweek|dayofmonth|dayofyear|usergroup|loginUser|page|treeLevel|PIDinRootline|PIDupinRootline|compatVersion|globalVar|globalString|global|userFunc|end|((?:\\{1,2}\\w+|\\w+\\\\{1,2})(?:\\w+\\\\{0,2})+))(?:\\s+=\\s+([^\\]]*))?",
+                    "captures": {
+                        "0": {
+                            "name": "variable.other.tsconfig"
+                        },
+                        "3": {
+                            "name": "string.unquoted.tsconfig"
+                        }
+                    }
+                },
+                {
+                    "include": "#condition-expression"
+                }
+            ]
+        },
+        "condition-expression": {
+            "patterns": [
+                {
+                    "match": "[0-9]+(?:\\.[0-9]+)?([Ee][\\+\\-][0-9]+)?",
+                    "name": "constant.numeric.other.symfonyexpression"
+                },
+                {
+                    "begin": "[\\(\\[\\{]",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.paren.open"
+                        }
+                    },
+                    "end": "[\\)\\]\\}]",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.paren.close"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#condition-expression"
+                        }
+                    ]
+                },
+                {
+                    "match": "\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|'([^'\\\\]*(?:\\\\.[^'\\\\]*)*)'",
+                    "name": "string.quoted.other.symfonyexpression"
+                },
+                {
+                    "match": "(?<=^|[\\s(])not in(?=[\\s(])|\\!\\=\\=|(?<=^|[\\s(])not(?=[\\s(])|(?<=^|[\\s(])and(?=[\\s(])|\\=\\=\\=|\\>\\=|(?<=^|[\\s(])or(?=[\\s(])|\\<\\=|\\*\\*|\\.\\.|(?<=^|[\\s(])in(?=[\\s(])|&&|\\|\\||(?<=^|[\\s(])matches|\\=\\=|\\!\\=|\\*|~|%|\\\/|\\>|\\||\\!|\\^|&|\\+|\\<|\\-",
+                    "name": "keyword.operator.other.symfonyexpression"
+                },
+                {
+                    "match": "[\\.,\\?\\:]",
+                    "name": "punctuation.other.symfonyexpression"
+                },
+                {
+                    "match": "[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*",
+                    "name": "variable.other.symfonyexpression"
                 }
             ]
         },

--- a/syntaxes/typoscript.tmLanguage.json
+++ b/syntaxes/typoscript.tmLanguage.json
@@ -103,10 +103,75 @@
             ]
         },
         "conditions": {
+            "begin": "\\[",
+            "end": "\\]",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.paren.open"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.paren.close"
+                }
+            },
             "patterns": [
                 {
-                    "name": "variable.other.typoscript",
-                    "match": "\\[(adminUser|language|IP|hostname|applicationContext|hour|minute|month|year|dayofweek|dayofmonth|dayofyear|usergroup|loginUser|page|treeLevel|PIDinRootline|PIDupinRootline|compatVersion|globalVar|globalString|global|userFunc|end|((?:\\{1,2}\\w+|\\w+\\\\{1,2})(?:\\w+\\\\{0,2})+)).*\\]"
+                    "match": "(adminUser|language|IP|hostname|applicationContext|hour|minute|month|year|dayofweek|dayofmonth|dayofyear|usergroup|loginUser|page|treeLevel|PIDinRootline|PIDupinRootline|compatVersion|globalVar|globalString|global|userFunc|end|((?:\\{1,2}\\w+|\\w+\\\\{1,2})(?:\\w+\\\\{0,2})+))(?:\\s+=\\s+([^\\]]*))?",
+                    "captures": {
+                        "0": {
+                            "name": "variable.other.typoscript"
+                        },
+                        "3": {
+                            "name": "string.unquoted.typoscript"
+                        }
+                    }
+                },
+                {
+                    "include": "#condition-expression"
+                }
+            ]
+        },
+        "condition-expression": {
+            "patterns": [
+                {
+                    "match": "[0-9]+(?:\\.[0-9]+)?([Ee][\\+\\-][0-9]+)?",
+                    "name": "constant.numeric.other.symfonyexpression"
+                },
+                {
+                    "begin": "[\\(\\[\\{]",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.paren.open"
+                        }
+                    },
+                    "end": "[\\)\\]\\}]",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.paren.close"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#condition-expression"
+                        }
+                    ]
+                },
+                {
+                    "match": "\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|'([^'\\\\]*(?:\\\\.[^'\\\\]*)*)'",
+                    "name": "string.quoted.other.symfonyexpression"
+                },
+                {
+                    "match": "(?<=^|[\\s(])not in(?=[\\s(])|\\!\\=\\=|(?<=^|[\\s(])not(?=[\\s(])|(?<=^|[\\s(])and(?=[\\s(])|\\=\\=\\=|\\>\\=|(?<=^|[\\s(])or(?=[\\s(])|\\<\\=|\\*\\*|\\.\\.|(?<=^|[\\s(])in(?=[\\s(])|&&|\\|\\||(?<=^|[\\s(])matches|\\=\\=|\\!\\=|\\*|~|%|\\\/|\\>|\\||\\!|\\^|&|\\+|\\<|\\-",
+                    "name": "keyword.operator.other.symfonyexpression"
+                },
+                {
+                    "match": "[\\.,\\?\\:]",
+                    "name": "punctuation.other.symfonyexpression"
+                },
+                {
+                    "match": "[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*",
+                    "name": "variable.other.symfonyexpression"
                 }
             ]
         },


### PR DESCRIPTION
Hey @benjaminkott! :wave:  Thanks for this VS code plugin! It has been immeasurably helpful for me so far. :tada:

I noticed that this plugin does not yet support syntax highlighting for TypoScript conditions, and even breaks completely on the new Symfony expression conditions:

<img width="308" alt="vscode-typoscript-condition" src="https://user-images.githubusercontent.com/2538958/85207333-59825980-b328-11ea-918a-9a4a9070d72f.png">

This PR adds full syntax highlighting support for TypoScript conditions (both using the legacy syntax and the new Symfony expressions) in both `.typoscript` and `.tsconfig` files:

<img width="588" alt="vscode-typoscript-condition-new" src="https://user-images.githubusercontent.com/2538958/85207632-204ae900-b32a-11ea-9c32-f579c7e5d306.png">

Hope this contribution proves useful. :wink: Cheers!
Martin

<hr>

**Attribution**:

The regular expressions used to match the tokens of the Symfony expression language have been adapted from the original Symfony expression language repo (MIT licensed) [1].

  [1]: https://github.com/symfony/expression-language/blob/master/Lexer.php